### PR TITLE
Fix hard dependency error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,30 @@
+# 2.0.0
+
+18.12.2025
+
+* Removed the `build <= 2.5.0` version constraint workaround
+  for [#170832](https://github.com/flutter/flutter/issues/170832)
+  thanks to [karolgajda-techsquare](https://github.com/karolgajda-techsquare).
+* Updated package dependencies.
+
 # 1.0.2
 
-* Fixed a rare bug when the generated file could contain imports to removed source files, 
+12.08.2025
+
+* Fixed a rare bug when the generated file could contain imports to removed source files,
   resulting in compile-time errors.
 
-  This occurred when build_runner failed to remove a `.g.` file after the source file was 
+  This occurred when build_runner failed to remove a `.g.` file after the source file was
   abruptly removed, for example, by version control.
 
 # 1.0.1
 
+05.07.2025
+
 * Updated the package description at pub.dev.
 
 # 1.0.0
+
+05.07.2025
 
 * Initial package release.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,17 +9,16 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  go_router: ^16.0.0
+  go_router: ^16.2.0
 
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
-  build_runner: ^2.4.15
-  go_router_builder: ^3.0.1
-  build_verify: ^3.1.1
-  go_router_aggregator: ^1.0.0
+  build_runner: ^2.6.0
+  go_router_builder: ^4.0.1
+  go_router_aggregator: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_aggregator
 description: >
   Aggregates GoRouter's generated type-safe routes into one importable file,
   separating your route declarations from the router setup.
-version: 1.0.2
+version: 2.0.0
 repository: https://github.com/mitryp/go_router_aggregator
 
 environment:
@@ -11,13 +11,13 @@ environment:
 dependencies:
   # a workaround for a braking change in `build`
   # https://github.com/flutter/flutter/issues/170832
-  build: ">=3.0.0 <5.0.0"
+  build: ^4.0.0
   glob: ^2.1.3
   path: ^1.9.0
 
 dev_dependencies:
-  build_runner: ^2.4.13
-  build_test: ^2.2.2
+  build_runner: ^2.6.0
+  build_test: ^3.4.1
   test: ^1.26.2
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   # a workaround for a braking change in `build`
   # https://github.com/flutter/flutter/issues/170832
-  build: ">=2.0.0 <2.5.0"
+  build: ">=3.0.0 <5.0.0"
   glob: ^2.1.3
   path: ^1.9.0
 

--- a/test/go_router_aggregator_test.dart
+++ b/test/go_router_aggregator_test.dart
@@ -210,8 +210,8 @@ class FooRoute extends GoRouteData {
         outputs: {
           'test|lib/routes.g.dart': decodedMatches(allOf(
             // both imports should appear, with distinct prefixes
-            contains("import 'package:test/foo/foo.dart' as _foo0;"),
-            contains("import 'package:test/bar/foo.dart' as _foo1;"),
+            contains(RegExp(r"import 'package:test/foo/foo.dart' as _foo\d;")),
+            contains(RegExp(r"import 'package:test/bar/foo.dart' as _foo\d;")),
             // and both spreads
             contains('..._foo0.\$appRoutes'),
             contains('..._foo1.\$appRoutes'),


### PR DESCRIPTION
Fixes:
Because go_router_builder >=4.1.1 depends on build >=3.0.0 <5.0.0 and every version of go_router_aggregator depends on build >=2.0.0 <2.5.0, go_router_builder
  >=4.1.1 is incompatible with go_router_aggregator.
So, because intecion_fsm depends on both go_router_builder ^4.1.3 and go_router_aggregator any, version solving failed.
Failed to update packages.

Seems like this breaking change is gone:
" # a workaround for a braking change in `build`
  # https://github.com/flutter/flutter/issues/170832"

Flutter  3.38.1
  go_router_builder: ^4.1.3
  build_runner: ^2.10.4
  
   go_router: ^17.0.0